### PR TITLE
fix: bump github/codeql-action from v4.36.2 to v4.36.3

### DIFF
--- a/.github/workflows/codeql-javascript-typescript.yml
+++ b/.github/workflows/codeql-javascript-typescript.yml
@@ -61,7 +61,7 @@ jobs:
         
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -89,6 +89,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Bump all github/codeql-action references (init, analyze, upload-sarif) from v4.36.2 to v4.36.3.

This fixes the cascading CodeQL version mismatch where init and analyze must share the same version to avoid config file version errors.